### PR TITLE
Fix sidechain lookahead arg name

### DIFF
--- a/BeatSmith.py
+++ b/BeatSmith.py
@@ -846,7 +846,7 @@ def main():
             if len(mix)  < LL: mix  = np.pad(mix,  (0, LL-len(mix)))
             if len(base) < LL: base = np.pad(base, (0, LL-len(base)))
             if args.sidechain > 0.0:
-                li(f"Applying lookahead sidechain amount={args.sidechain:.2f} lookahead={args.sidechain-lookahead-ms if hasattr(args,'sidechain_lookahead_ms') else 0}ms")
+                li(f"Applying lookahead sidechain amount={args.sidechain:.2f} lookahead={args.sidechain_lookahead_ms if hasattr(args,'sidechain_lookahead_ms') else 0}ms")
                 mix = lookahead_sidechain(mix, base, TARGET_SR, amount=float(max(0.0, min(args.sidechain, 1.0))), look_ms=float(max(0.0, args.sidechain_lookahead_ms)))
             # equal-power-ish mix
             mix = (0.5*base + 0.5*mix).astype(np.float32)


### PR DESCRIPTION
## Summary
- fix sidechain lookahead argument reference in log message

## Testing
- `python -m py_compile BeatSmith.py`
- `python - <<'PY'
import argparse, logging
LOG_FORMAT = "%(message)s"
logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
def li(msg: str): logging.info("[i] " + msg)
p = argparse.ArgumentParser()
p.add_argument("--sidechain", type=float, default=0.0)
p.add_argument("--sidechain-lookahead-ms", type=float, default=0.0)
args = p.parse_args(["--sidechain","0.5","--sidechain-lookahead-ms","15"])
li(f"Applying lookahead sidechain amount={args.sidechain:.2f} lookahead={args.sidechain_lookahead_ms if hasattr(args,'sidechain_lookahead_ms') else 0}ms")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a2a6ed16c0833185da09669b5f67bb