### PR TITLE
Add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Lint
+        run: ruff check tests
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ See `ROADMAP.md` for concrete plugin/registry plans and task breakdowns.
 
 ---
 
+## Testing
+        # Install test and lint dependencies
+        pip install -e .[test]
+
+        # Run style checks
+        ruff check tests
+
+        # Execute unit tests
+        pytest
+
+---
+
 ## Licensing & Ethics
 	- BeatSmith is an art/sonification engine. You are responsible for how you use the outputs.
 	- We *prefer* Creative Commons / Public Domain assets and expose a license allow-list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,16 @@ dependencies = [
 [project.scripts]
 beatsmith = "beatsmith.cli:main"
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "ruff",
+]
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the path for tests without installing the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_audio_utils.py
+++ b/tests/test_audio_utils.py
@@ -1,0 +1,45 @@
+import argparse
+import numpy as np
+import pytest
+
+from beatsmith.audio import (
+    MeasureSpec,
+    parse_sig_map,
+    crossfade_concat,
+    time_stretch_to_length,
+)
+
+
+# ---------------------- parse_sig_map ----------------------
+
+def test_parse_sig_map_valid():
+    sig = "4/4(2), 3/8(1)"
+    specs = parse_sig_map(sig)
+    assert specs == [MeasureSpec(4, 4, 2), MeasureSpec(3, 8, 1)]
+
+
+def test_parse_sig_map_invalid():
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_sig_map("4/5(2)")
+
+
+# ---------------------- crossfade_concat ----------------------
+
+def test_crossfade_concat_continuity():
+    sr = 1000
+    a = np.ones(sr, dtype=np.float32)
+    b = np.ones(sr, dtype=np.float32)
+    out = crossfade_concat([a, b], sr, fade_s=0.1)
+    fade = int(0.1 * sr)
+    assert len(out) == sr * 2 - fade
+    assert np.allclose(out, 1.0, atol=1e-6)
+
+
+# ---------------------- time_stretch_to_length ----------------------
+
+@pytest.mark.parametrize("mode", ["off", "loose", "strict"])
+@pytest.mark.parametrize("target", [50, 150])
+def test_time_stretch_to_length_length(mode, target):
+    seg = np.linspace(0, 1, 100).astype(np.float32)
+    y, _ = time_stretch_to_length(seg, sr=100, target_len=target, mode=mode)
+    assert len(y) == target


### PR DESCRIPTION
## Summary
- configure pytest and test dependencies
- add unit tests for signature parsing, crossfade, and time-stretch utilities
- document testing flow and add CI workflow for lint and tests

## Testing
- `ruff check tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39613c4d48331bb36e5127186a0f5