### PR TITLE
Add dry-run and inspect subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,18 @@ BeatSmith prints the chosen `seed`/`salt`, `sig_map`, preset, BPM, query bias, F
 		--stems
 
 	# Build on your existing loop with lookahead sidechain pumping
-	python -m beatsmith out "4/4(16)" --bpm 124 --build-on ./my_loop.wav \
-		--sidechain 0.6 --sidechain-lookahead-ms 10 --preset edm
+        python -m beatsmith out "4/4(16)" --bpm 124 --build-on ./my_loop.wav \
+                --sidechain 0.6 --sidechain-lookahead-ms 10 --preset edm
 
-### 3) Presets
+### 3) Dry run (plan without downloads)
+        # See planned measures and candidate sources, but skip audio fetch
+        python -m beatsmith out "4/4(8)" --dry-run
+
+### 4) Inspect previous run
+        # Show summary of latest beatsmith_v3.db under current directory
+        beatsmith inspect
+
+### 5) Presets
 	--preset boom-bap | edm | lofi
 
 Presets bias EQ, FX, and query terms sensibly. You can still override any knob.
@@ -96,7 +104,8 @@ Presets bias EQ, FX, and query terms sensibly. You can still override any knob.
 	  sig_map                     Signature program like "4/4(4),5/4(3),6/8(5)". Autopilot picks one if omitted.
 
 	Core:
-	  --auto                      Force Autopilot (random banks).
+          --auto                      Force Autopilot (random banks).
+          --dry-run                   Print planned sources/measures and exit.
 	  --bpm FLOAT                 Global BPM (Autopilot picks a sane range per preset).
 	  --seed STR                  Deterministic seed.
 	  --salt STR                  Additional salt to create alternate takes deterministically.

--- a/src/beatsmith/__main__.py
+++ b/src/beatsmith/__main__.py
@@ -1,4 +1,16 @@
-from .cli import main
+import sys
+
+from .cli import main as run_main
+from .inspect import main as inspect_main
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "inspect":
+        sys.argv.pop(1)
+        inspect_main()
+    else:
+        run_main()
+
 
 if __name__ == "__main__":
     main()

--- a/src/beatsmith/inspect.py
+++ b/src/beatsmith/inspect.py
@@ -1,0 +1,38 @@
+import argparse
+from typing import Optional
+
+from . import li, le
+from .db import db_open, find_latest_db, read_last_run
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Summarize latest BeatSmith run.")
+    p.add_argument("--root", type=str, default=".", help="Search root for beatsmith_v3.db")
+    p.add_argument("--db", type=str, default=None, help="Explicit path to beatsmith_v3.db")
+    return p
+
+
+def main(argv: Optional[list[str]] = None):
+    args = build_parser().parse_args(argv)
+    db_path = args.db or find_latest_db(args.root)
+    if not db_path:
+        le("No beatsmith_v3.db found")
+        return
+    conn = db_open(db_path)
+    run = read_last_run(conn)
+    if not run:
+        le("No runs recorded in DB")
+        return
+    li(f"DB: {db_path}")
+    li(
+        f"Run id={run['id']} created={run['created_at']} BPM={run['bpm']} "
+        f"sig_map={run['sig_map']} seed={run['seed']} salt={run['salt']}"
+    )
+    if run["params"]:
+        li("Params:")
+        for k in sorted(run["params"].keys()):
+            li(f"  {k}: {run['params'][k]}")
+    li(f"Sources: {run['num_sources']}  segments: {run['num_segments']}")
+
+
+__all__ = ["main"]

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,39 @@
+import time
+
+from beatsmith.db import db_open, find_latest_db, read_last_run
+
+
+def test_read_last_run(tmp_path):
+    db_path = tmp_path / "beatsmith_v3.db"
+    conn = db_open(str(db_path))
+    conn.execute(
+        "INSERT INTO runs(created_at,out_dir,bpm,sig_map,seed,salt,params_json) VALUES (datetime('now'),?,?,?,?,?,?)",
+        ("out", 120.0, "4/4(1)", "seed", "salt", '{"preset":"boom"}')
+    )
+    run_id = conn.execute("SELECT id FROM runs").fetchone()[0]
+    conn.execute(
+        "INSERT INTO sources(run_id,url,bus,duration_s,picked) VALUES (?,?,?,?,1)",
+        (run_id, "u", "perc", 1.0)
+    )
+    conn.execute(
+        "INSERT INTO segments(run_id,measure_index,numer,denom,bus,start_s,dur_s,source_id) VALUES (?,?,?,?,?,?,?,1)",
+        (run_id, 0, 4, 4, "perc", 0.0, 1.0)
+    )
+    conn.commit()
+    info = read_last_run(conn)
+    assert info and info["id"] == run_id
+    assert info["num_sources"] == 1
+    assert info["num_segments"] == 1
+    assert info["params"]["preset"] == "boom"
+
+
+def test_find_latest_db(tmp_path):
+    older = tmp_path / "a" / "beatsmith_v3.db"
+    newer = tmp_path / "b" / "beatsmith_v3.db"
+    older.parent.mkdir()
+    newer.parent.mkdir()
+    older.touch()
+    time.sleep(0.1)
+    newer.touch()
+    found = find_latest_db(str(tmp_path))
+    assert found and found.endswith(str(newer))


### PR DESCRIPTION
## Summary
- add `--dry-run` option to preview measures and candidate sources without downloading audio
- implement `beatsmith inspect` subcommand for summarizing latest run
- factor reusable DB utilities and document new features

## Testing
- `ruff check tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39a5c48288331a79dc84cccf71196