### PR TITLE
refactor: add provider abstraction

### DIFF
--- a/src/beatsmith/providers/__init__.py
+++ b/src/beatsmith/providers/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import random
+from typing import Protocol, List, Dict, Optional
+
+AUDIO_EXTS = {
+    ".wav", ".wave", ".aif", ".aiff", ".flac", ".mp3", ".ogg", ".oga", ".m4a"
+}
+
+class Provider(Protocol):
+    def search(
+        self,
+        rng: random.Random,
+        wanted: int,
+        query_bias: Optional[str],
+        allow_tokens: List[str],
+        strict: bool,
+    ) -> List[Dict]:
+        """Return a list of candidate file infos."""
+
+    def fetch(self, file_info: Dict, cache_dir: str) -> Optional[bytes]:
+        """Fetch raw bytes for the given file."""
+
+    def license(self, file_info: Dict) -> Optional[str]:
+        """Return license information for the given file."""
+
+def license_ok(licenseurl: Optional[str], allow_tokens: List[str]) -> bool:
+    if not licenseurl:
+        return False
+    low = licenseurl.lower()
+    for tok in allow_tokens:
+        t = tok.strip().lower()
+        if t and t in low:
+            return True
+    return False

--- a/src/beatsmith/providers/local.py
+++ b/src/beatsmith/providers/local.py
@@ -1,0 +1,51 @@
+import os
+import random
+from typing import List, Dict, Optional
+
+from . import AUDIO_EXTS
+
+
+class LocalProvider:
+    """Simple local-folder provider scaffold."""
+
+    def __init__(self, root: str = "."):
+        self.root = root
+
+    def search(
+        self,
+        rng: random.Random,
+        wanted: int,
+        query_bias: Optional[str],
+        allow_tokens: List[str],
+        strict: bool,
+    ) -> List[Dict]:
+        files: List[Dict] = []
+        for dirpath, _, filenames in os.walk(self.root):
+            for fn in filenames:
+                lower = fn.lower()
+                if any(lower.endswith(ext) for ext in AUDIO_EXTS):
+                    path = os.path.join(dirpath, fn)
+                    files.append(
+                        {
+                            "identifier": path,
+                            "name": fn,
+                            "title": fn,
+                            "licenseurl": None,
+                            "url": path,
+                        }
+                    )
+        rng.shuffle(files)
+        return files
+
+    def fetch(self, file_info: Dict, cache_dir: str) -> Optional[bytes]:
+        path = file_info.get("url")
+        if not path:
+            return None
+        try:
+            with open(path, "rb") as f:
+                return f.read()
+        except Exception:
+            return None
+
+    def license(self, file_info: Dict) -> Optional[str]:
+        return file_info.get("licenseurl")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from beatsmith import ia
+from beatsmith.providers import internet_archive as ia
 
 
 class DummyResponse:


### PR DESCRIPTION
## Summary
- add a generic Provider interface and InternetArchiveProvider implementation
- refactor audio source selection to use the chosen provider
- expose provider selection via CLI and stub a LocalProvider for future use

## Testing
- `ruff check src/beatsmith/providers/__init__.py src/beatsmith/providers/internet_archive.py src/beatsmith/providers/local.py src/beatsmith/audio.py src/beatsmith/cli.py tests/test_retry.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39d44df908331822332389bc61a8f