### PR TITLE
Ensure test_retry imports explicit

### DIFF
--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,5 +1,5 @@
-import random
 import sys
+import random
 from pathlib import Path
 from unittest.mock import Mock
 


### PR DESCRIPTION
## Summary
- Reorder imports at the top of `test_retry` to explicitly include `sys`, `random`, `Path`, and `Mock`

## Testing
- `pytest tests/test_retry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b4af4d4c8331bfee84954b77c928