### PR TITLE
Ensure temp files cleaned after decoding

### DIFF
--- a/src/beatsmith/audio.py
+++ b/src/beatsmith/audio.py
@@ -78,10 +78,15 @@ def load_audio_from_bytes(
         if ext:
             suffix = ext
 
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp_path = tmp.name
         tmp.write(b)
         tmp.flush()
-        y, srr = librosa.load(tmp.name, sr=sr, mono=True)
+
+    try:
+        y, srr = librosa.load(tmp_path, sr=sr, mono=True)
+    finally:
+        os.remove(tmp_path)
 
     if not np.isfinite(y).any() or y.size == 0:
         raise ValueError("Decoded audio is empty/invalid")


### PR DESCRIPTION
## Summary
- Manually remove temporary files created during `load_audio_from_bytes`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e4efc72083318a40b19f8b300985