### PR TITLE
Add argparse subcommand for inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ BeatSmith prints the chosen `seed`/`salt`, `sig_map`, preset, BPM, query bias, F
         python -m beatsmith out "4/4(8)" --dry-run
 
 ### 4) Inspect previous run
-        # Show summary of latest beatsmith_v3.db under current directory
+        # `inspect` subcommand: summarize latest beatsmith_v3.db under current directory
         beatsmith inspect
 
 ### 5) Presets

--- a/src/beatsmith/__main__.py
+++ b/src/beatsmith/__main__.py
@@ -1,14 +1,25 @@
+import argparse
 import sys
 
 from .cli import main as run_main
 from .inspect import main as inspect_main
 
 
-def main():
-    if len(sys.argv) > 1 and sys.argv[1] == "inspect":
-        sys.argv.pop(1)
-        inspect_main()
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="beatsmith")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("inspect", help="Summarize latest BeatSmith run.")
+    return parser
+
+
+def main(argv: list[str] | None = None):
+    argv = sys.argv[1:] if argv is None else argv
+    parser = build_parser()
+    args, remainder = parser.parse_known_args(argv)
+    if args.command == "inspect":
+        inspect_main(remainder)
     else:
+        sys.argv = [sys.argv[0]] + remainder
         run_main()
 
 


### PR DESCRIPTION
## Summary
- route `beatsmith inspect` through an argparse subcommand
- document the new inspect invocation syntax

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb0b399883319e06cf1a590e3328