### PR TITLE
feat(local-provider): add query and license filtering

### DIFF
--- a/src/beatsmith/providers/local.py
+++ b/src/beatsmith/providers/local.py
@@ -2,11 +2,21 @@ import os
 import random
 from typing import List, Dict, Optional
 
-from . import AUDIO_EXTS
+from . import AUDIO_EXTS, license_ok
 
 
 class LocalProvider:
-    """Simple local-folder provider scaffold."""
+    """Search for audio files in a local directory.
+
+    This provider recursively scans ``root`` for files whose extensions match
+    :data:`~beatsmith.providers.AUDIO_EXTS`.  When ``query_bias`` is provided it
+    is split on whitespace into tokens and only files whose name (case
+    insensitive) contains at least one of those tokens will be returned.
+
+    License information can optionally be supplied via ``<filename>.license``
+    sidecar files containing a license URL.  When ``strict`` is ``True`` only
+    files with a license that matches one of ``allow_tokens`` will be yielded.
+    """
 
     def __init__(self, root: str = "."):
         self.root = root
@@ -19,18 +29,33 @@ class LocalProvider:
         allow_tokens: List[str],
         strict: bool,
     ) -> List[Dict]:
+        tokens = []
+        if query_bias:
+            tokens = [t.strip().lower() for t in query_bias.split() if t.strip()]
         files: List[Dict] = []
         for dirpath, _, filenames in os.walk(self.root):
             for fn in filenames:
                 lower = fn.lower()
+                if tokens and not any(t in lower for t in tokens):
+                    continue
                 if any(lower.endswith(ext) for ext in AUDIO_EXTS):
                     path = os.path.join(dirpath, fn)
+                    licenseurl: Optional[str] = None
+                    lic_path = path + ".license"
+                    if os.path.isfile(lic_path):
+                        try:
+                            with open(lic_path, "r", encoding="utf-8") as lf:
+                                licenseurl = lf.read().strip() or None
+                        except Exception:
+                            licenseurl = None
+                    if strict and not license_ok(licenseurl, allow_tokens):
+                        continue
                     files.append(
                         {
                             "identifier": path,
                             "name": fn,
                             "title": fn,
-                            "licenseurl": None,
+                            "licenseurl": licenseurl,
                             "url": path,
                         }
                     )

--- a/tests/test_local_provider.py
+++ b/tests/test_local_provider.py
@@ -1,0 +1,41 @@
+import random
+from pathlib import Path
+
+from beatsmith.providers.local import LocalProvider
+
+
+def _touch(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"data")
+
+
+def test_query_filtering(tmp_path):
+    _touch(tmp_path / "cat.wav")
+    _touch(tmp_path / "dog.mp3")
+    _touch(tmp_path / "bird.wav")
+
+    provider = LocalProvider(str(tmp_path))
+    rng = random.Random(0)
+    results = provider.search(rng, wanted=10, query_bias="cat dog", allow_tokens=[], strict=False)
+    names = sorted(f["name"] for f in results)
+    assert names == ["cat.wav", "dog.mp3"]
+
+
+def test_strict_license_enforcement(tmp_path):
+    allow = tmp_path / "allow.wav"
+    _touch(allow)
+    (allow.with_suffix(".wav.license")).write_text("CC0 1.0")
+
+    deny = tmp_path / "deny.wav"
+    _touch(deny)
+    (deny.with_suffix(".wav.license")).write_text("GPL")
+
+    no_license = tmp_path / "nolicense.wav"
+    _touch(no_license)
+
+    provider = LocalProvider(str(tmp_path))
+    rng = random.Random(0)
+    results = provider.search(rng, wanted=10, query_bias=None, allow_tokens=["cc0"], strict=True)
+    names = sorted(f["name"] for f in results)
+    assert names == ["allow.wav"]
+    assert results[0]["licenseurl"] == "CC0 1.0"


### PR DESCRIPTION
## Summary
- support tokenized query filtering and optional license sidecars in `LocalProvider`
- document provider filtering behavior
- add tests for query matching and strict license enforcement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5335922bc83318f25bb3d7eb48eec