### PR TITLE
docs: expand installation with Windows venv and ffmpeg notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,18 @@ Deterministic, Internet Archive–powered beat builder that slices audible, onse
         # System requirements
         - Python 3.10+
         - ffmpeg (for decoding MP3/OGG/etc through librosa/audioread)
+            - macOS: `brew install ffmpeg`
+            - Debian/Ubuntu: `sudo apt install ffmpeg`
+            - Windows: https://ffmpeg.org/download.html or `choco install ffmpeg`
         - macOS/Linux/WSL tested; Windows should work with ffmpeg on PATH
 
+        # Verify ffmpeg is available
+        ffmpeg -version
+
         # Create env and install the project
-        python3 -m venv .venv && source .venv/bin/activate
+        python3 -m venv .venv
+        source .venv/bin/activate  # macOS/Linux
+        .\.venv\Scripts\activate  # Windows PowerShell
         pip install -e .  # or `pip install .`
 
 ---


### PR DESCRIPTION
## Summary
- document macOS, Linux, and Windows steps for installing ffmpeg
- add Windows venv activation syntax and ffmpeg availability check

## Testing
- `ruff check tests`
- `pytest` *(fails: tests/test_audio_utils.py::test_crossfade_click_free_boundaries)*

------
https://chatgpt.com/codex/tasks/task_e_68a53e7bfbb4833191185e69fc1ca779