### PR TITLE
Improve Schroeder reverb stability and add test

### DIFF
--- a/tests/test_reverb.py
+++ b/tests/test_reverb.py
@@ -1,0 +1,10 @@
+import numpy as np
+from beatsmith.fx import reverb_schroeder
+
+def test_reverb_schroeder_finite_and_non_silent():
+    sr = 44100
+    rng = np.random.default_rng(0)
+    y = rng.standard_normal(sr).astype(np.float32)
+    out = reverb_schroeder(y, sr)
+    assert np.all(np.isfinite(out))
+    assert np.any(np.abs(out) > 1e-7)


### PR DESCRIPTION
## Summary
- Replace reverb all-pass implementation with standard Schroeder delay-line formulation using float64 internals
- Clamp feedback gains and sanitize stage outputs for stability
- Test reverb output for finiteness and non-silence

## Testing
- `ruff check src/beatsmith/fx.py tests/test_reverb.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea14d2ec83318c9b7936715b05d8