### PR TITLE
Sanitize audio output before saving

### DIFF
--- a/src/beatsmith/cli.py
+++ b/src/beatsmith/cli.py
@@ -14,7 +14,7 @@ from .db import db_open
 from .audio import (
     parse_sig_map, seconds_per_measure, seeded_rng, normalize_peak,
     load_audio_file, pick_sources, build_measures, assemble_track, TARGET_SR,
-    preview_sources,
+    preview_sources, safe_audio,
 )
 from .fx import (
     compressor, eq_three_band, reverb_schroeder, tremolo, phaser, echo, lookahead_sidechain
@@ -313,6 +313,7 @@ def main():
         wet = echo(mix.copy(), TARGET_SR, delay_ms=args.echo_ms, feedback=args.echo_fb, mix=args.echo_mix)
         mix = (0.75*mix + 0.25*wet).astype(np.float32)
     mix = normalize_peak(mix, peak_db=-0.8)
+    mix = safe_audio(mix)
     out_wav = os.path.join(out_dir, f"beatsmith_v3_{run_id}.wav")
     sf.write(out_wav, mix, TARGET_SR, subtype="PCM_16")
     li(f"Wrote: {out_wav}")

--- a/tests/test_safe_audio.py
+++ b/tests/test_safe_audio.py
@@ -1,0 +1,18 @@
+import io
+
+import numpy as np
+import soundfile as sf
+
+from beatsmith.audio import normalize_peak, safe_audio, TARGET_SR
+
+
+def test_safe_audio_removes_nans_before_write():
+    y = np.array([0.25, -0.25, 0.5, -0.5], dtype=np.float32)
+    y = normalize_peak(y)
+    y[2] = np.nan  # effect introduces NaN
+    buf = io.BytesIO()
+    sf.write(buf, safe_audio(y), TARGET_SR, format="WAV")
+    buf.seek(0)
+    out, sr = sf.read(buf, dtype="float32")
+    assert np.isfinite(out).all()
+    assert np.max(np.abs(out)) > 0.0


### PR DESCRIPTION
## Summary
- add `safe_audio` helper to clamp audio and zero out non-finite samples
- sanitize stems and final mix through `safe_audio` before writing
- regression test ensures NaNs injected by effects don't reach written audio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a603d6dd74833192b790f9855876d8