### PR TITLE
Quantize slices and stack grooves

### DIFF
--- a/src/beatsmith/cli.py
+++ b/src/beatsmith/cli.py
@@ -82,6 +82,7 @@ def autopilot_config(rng) -> Dict[str, Any]:
         "preset": preset,
         "bpm": float(bpm),
         "num_sources": rng.randint(4, 8),
+        "num_sounds": rng.randint(15, 30),
         "crossfade": rng.uniform(0.01, 0.04),
         "stems": rng.random() < 0.3,
         "microfill": rng.random() < 0.5,
@@ -120,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--strict-license", action="store_true", help="Enforce license allow-list strictly (no fallback).")
     p.add_argument("--cache-dir", type=str, default=os.path.expanduser("~/.beatsmith/cache"), help="Download cache directory.")
     p.add_argument("--min-rms", type=float, default=0.02, help="Minimum RMS for audible slice.")
+    p.add_argument("--num-sounds", type=int, default=None, help="Number of slices to generate (default: 15-30 random).")
     p.add_argument("--crossfade", type=float, default=0.02, help="Seconds of crossfade between measures.")
     p.add_argument("--tempo-fit", choices=["off","loose","strict"], default="strict", help="Time-stretch mode to fit global measure length.")
     p.add_argument("--stems", action="store_true", help="Write stems per bus/measure.")
@@ -274,6 +276,7 @@ def main():
         microfill=args.microfill,
         beat_align=bool(args.beat_align),
         refine_boundaries=args.boundary_refine,
+        num_sounds=args.num_sounds,
     )
     tex_gain = 10 ** (-3.0 / 20.0)
     L = max(len(mix_perc), len(mix_tex))

--- a/tests/test_quantization_groove.py
+++ b/tests/test_quantization_groove.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from beatsmith.audio import duration_samples_map, stack_slices, TARGET_SR
+
+def test_duration_samples_map_quantization():
+    bpm = 120.0
+    mapping = duration_samples_map(bpm)
+    unit = mapping["1/16"]
+    # quarter note at 120 BPM is 0.5s -> ≈22050 samples (allow 2-sample rounding)
+    assert abs(mapping["1/4"] - int(0.5 * TARGET_SR)) <= 2
+    # dotted eighth is 1.5 times an eighth
+    assert mapping["dotted 1/8"] == int(round(1.5 * mapping["1/8"]))
+    for name, samples in mapping.items():
+        if "dotted" not in name:
+            assert samples % unit == 0
+
+def test_stack_slices_overlap():
+    length = 16
+    a = np.ones(4, dtype=np.float32)
+    b = np.full(4, 0.5, dtype=np.float32)
+    out = stack_slices(length, [(a, 0), (b, 2)])
+    expected = np.zeros(length, dtype=np.float32)
+    expected[0:4] += a
+    expected[2:6] += b
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- map musical note values (including dotted durations) to sample counts
- slice and stack quantized snippets within measures, scheduling via new groove routine
- expose `--num-sounds` flag and default 15-30 slice generation with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6840ba6288331b4ce0fd929812193