### PR TITLE
Reduce default reverb/tremolo usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,14 @@ Presets bias EQ, FX, and query terms sensibly. You can still override any knob.
 	  --comp-makeup FLOAT         Makeup gain dB (default +2)
 	  --eq-low/--eq-mid/--eq-high FLOAT  3-band EQ gains (dB)
 	  --reverb-mix FLOAT          0..1 (0 disables)
-	  --reverb-room FLOAT         0..1
-	  --tremolo-rate FLOAT        Hz (0 disables)
-	  --tremolo-depth FLOAT       0..1
-	  --phaser-rate FLOAT         Hz (0 disables)
-	  --phaser-depth FLOAT        0..1
-	  --echo-ms FLOAT             ms (0 disables)
+          --reverb-room FLOAT         0..1
+          --tremolo-rate FLOAT        Hz (0 disables)
+          --tremolo-depth FLOAT       0..1
+          --force-reverb              Autopilot: always include reverb
+          --force-tremolo             Autopilot: always include tremolo
+          --phaser-rate FLOAT         Hz (0 disables)
+          --phaser-depth FLOAT        0..1
+          --echo-ms FLOAT             ms (0 disables)
 	  --echo-fb FLOAT             0..1 feedback
 	  --echo-mix FLOAT            0..1 wet mix
 

--- a/tests/test_autopilot_dry.py
+++ b/tests/test_autopilot_dry.py
@@ -1,0 +1,29 @@
+import random
+
+from beatsmith.cli import autopilot_config
+
+
+def test_autopilot_usually_dry():
+    rng = random.Random(0)
+    wet_reverb = 0
+    wet_trem = 0
+    N = 100
+    for _ in range(N):
+        cfg = autopilot_config(rng)
+        if cfg["reverb_mix"] > 0:
+            wet_reverb += 1
+        else:
+            assert cfg["reverb_room"] == 0
+        if cfg["tremolo_rate"] > 0:
+            wet_trem += 1
+        else:
+            assert cfg["tremolo_depth"] == 0
+    assert wet_reverb <= N * 0.2
+    assert wet_trem <= N * 0.2
+
+
+def test_autopilot_force_effects():
+    rng = random.Random(123)
+    cfg = autopilot_config(rng, force_reverb=True, force_tremolo=True)
+    assert cfg["reverb_mix"] > 0 and cfg["reverb_room"] > 0
+    assert cfg["tremolo_rate"] > 0 and cfg["tremolo_depth"] > 0


### PR DESCRIPTION
## Summary
- Stop presets from automatically adding reverb or tremolo
- Autopilot now rarely uses reverb/tremolo and zeroes parameters when disabled
- Add `--force-reverb` and `--force-tremolo` flags to opt in
- Document new flags and test that autopilot output is typically dry

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a68ab8b20c833189cbf986c50d4711