### PR TITLE
Add pattern fixtures and adapter tests

### DIFF
--- a/tests/fixtures/pattern.json
+++ b/tests/fixtures/pattern.json
@@ -1,0 +1,1 @@
+{"signature": "4/4", "bars": 1, "subdivision": 16, "lanes": {"kick": [0], "snare": [8]}}

--- a/tests/test_pattern_adapter.py
+++ b/tests/test_pattern_adapter.py
@@ -1,0 +1,46 @@
+import random
+
+import numpy as np
+
+from beatsmith.pattern_adapter import apply_pattern_to_quantized_slices
+
+
+def test_step_to_time_conversion():
+    pattern = {
+        "signature": "4/4",
+        "bars": 1,
+        "subdivision": 16,
+        "lanes": {"kick": [0, 1, 2]},
+    }
+    sample = np.ones(10, dtype=np.float32)
+    out = apply_pattern_to_quantized_slices(pattern, {"kick": [sample]}, 120.0)
+    times = [p.start_s for p in out]
+    assert np.allclose(times, [0.0, 0.125, 0.25])
+
+
+def test_swing_offsets():
+    pattern = {"signature": "4/4", "bars": 1, "subdivision": 16, "lanes": {"kick": [0, 1]}}
+    sample = np.ones(10, dtype=np.float32)
+    out = apply_pattern_to_quantized_slices(pattern, {"kick": [sample]}, 120.0, swing=0.5)
+    times = [p.start_s for p in out]
+    assert np.allclose(times, [0.0, 0.1875])
+
+
+def test_humanize_jitter():
+    pattern = {"signature": "4/4", "bars": 1, "subdivision": 16, "lanes": {"kick": [0]}}
+    sample = np.ones(10, dtype=np.float32)
+    rng = random.Random(0)
+    out = apply_pattern_to_quantized_slices(
+        pattern, {"kick": [sample]}, 120.0, humanize_s=0.01, rng=rng
+    )
+    assert len(out) == 1
+    assert abs(out[0].start_s - 0.006888437) < 1e-6
+
+
+def test_velocity_scaling():
+    pattern = {"signature": "4/4", "bars": 1, "subdivision": 16, "lanes": {"snare": [(0, 0.5)]}}
+    sample = np.ones(4, dtype=np.float32)
+    out = apply_pattern_to_quantized_slices(
+        pattern, {"snare": [sample]}, 120.0, velocity_scale=0.2
+    )
+    assert np.allclose(out[0].data, 0.1)

--- a/tests/test_pattern_integration.py
+++ b/tests/test_pattern_integration.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import random
+import importlib.util
+
+import numpy as np
+from mido import MidiFile, MidiTrack, Message
+
+spec = importlib.util.spec_from_file_location(
+    "drum_patterns", Path(__file__).resolve().parents[1] / "tools" / "drum_patterns.py"
+)
+drum_patterns = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(drum_patterns)
+
+from beatsmith.pattern_adapter import apply_pattern_to_quantized_slices
+
+
+def _write_test_midi(path: Path) -> None:
+    mid = MidiFile()
+    track = MidiTrack()
+    mid.tracks.append(track)
+    tpb = mid.ticks_per_beat
+    track.append(Message("note_on", note=36, velocity=100, time=0))
+    track.append(Message("note_on", note=38, velocity=100, time=2 * tpb))
+    mid.save(path)
+
+
+def test_ingest_and_apply(tmp_path):
+    midi_path = tmp_path / "simple.mid"
+    _write_test_midi(midi_path)
+    db = tmp_path / "patterns.db"
+    drum_patterns.ingest(db, [midi_path], subdivision=16)
+    pattern = drum_patterns.sample(db)
+    assert pattern and pattern["lanes"] == {"kick": [0], "snare": [8]}
+    registry = {
+        "kick": [np.ones(1, dtype=np.float32)],
+        "snare": [np.ones(1, dtype=np.float32)],
+    }
+    placements = apply_pattern_to_quantized_slices(
+        pattern, registry, 120.0, rng=random.Random(0)
+    )
+    times = [p.start_s for p in placements]
+    assert np.allclose(times, [0.0, 1.0])
+


### PR DESCRIPTION
## Summary
- add minimal drum pattern JSON and MIDI fixtures
- test step-to-time conversion, swing, humanize, and velocity scaling
- verify MIDI ingest and deterministic placement end-to-end
- generate test MIDI programmatically to avoid binary fixtures

## Testing
- `pytest tests/test_pattern_adapter.py tests/test_pattern_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d540c63c83319ec0e8deeb4c1298