### PR TITLE
docs: add pattern oracle guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,32 @@ See `ROADMAP.md` for concrete plugin/registry plans and task breakdowns.
 ---
 
 ## Examples
-	# Groovey EDM Autopilot with stems
-	python -m beatsmith --auto --preset edm --stems
+        # Groovey EDM Autopilot with stems
+        python -m beatsmith --auto --preset edm --stems
 
-	# Tight 7/8 texture piece from ambient sources
-	python -m beatsmith out "7/8(12)" --bpm 126 --preset lofi \
-		--query-bias "ambient texture OR pad" --tempo-fit loose --stems
+        # Tight 7/8 texture piece from ambient sources
+        python -m beatsmith out "7/8(12)" --bpm 126 --preset lofi \
+                --query-bias "ambient texture OR pad" --tempo-fit loose --stems
+
+---
+
+## Pattern Oracle (optional)
+BeatSmith can optionally overlay quantized drum patterns sourced from MIDI files.
+
+### Build the pattern database
+        pip install mido
+        python tools/drum_patterns.py ingest <midi_dir>
+
+This creates `~/.beatsmith/patterns.db` by default; pass `--db` to override.
+
+### Enable pattern overlay
+        python -m beatsmith out "4/4(8)" --bpm 120 \\
+                --pattern-enable --pattern-db ~/.beatsmith/patterns.db \\
+                --pattern-sig 4/4 --pattern-lane-map kick=perc,snare=perc
+
+`--pattern-enable` turns on pattern placement. Without `--pattern-db`, BeatSmith
+looks for `~/.beatsmith/patterns.db`. By default all lanes pull from the `perc`
+bus; override with `--pattern-lane-map lane=bus,...`.
 
 ---
 

--- a/tests/test_pattern_integration.py
+++ b/tests/test_pattern_integration.py
@@ -1,17 +1,17 @@
 from pathlib import Path
-import random
 import importlib.util
+import random
 
 import numpy as np
 from mido import MidiFile, MidiTrack, Message
+
+from beatsmith.pattern_adapter import apply_pattern_to_quantized_slices
 
 spec = importlib.util.spec_from_file_location(
     "drum_patterns", Path(__file__).resolve().parents[1] / "tools" / "drum_patterns.py"
 )
 drum_patterns = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(drum_patterns)
-
-from beatsmith.pattern_adapter import apply_pattern_to_quantized_slices
 
 
 def _write_test_midi(path: Path) -> None:


### PR DESCRIPTION
## Summary
- document optional MIDI-derived Pattern Oracle and its CLI flags
- fix test import order for clean `ruff` run

## Testing
- `ruff check tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7d8b2ed088331b5ce82c998f09703