### PR TITLE
refactor: centralize drum pattern constants

### DIFF
--- a/src/beatsmith/pattern_adapter.py
+++ b/src/beatsmith/pattern_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Utilities for adapting drum patterns to quantized sample slices.
 
 This module provides :func:`apply_pattern_to_quantized_slices` which maps a
@@ -28,35 +26,15 @@ The goal is to stay lightweight while being flexible enough for tests and
 future features.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Dict, List, Mapping, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence
 import random
 
 import numpy as np
 
-# ---------------------------------------------------------------------------
-# General MIDI note -> lane mapping
-# ---------------------------------------------------------------------------
-
-# Mapping of General MIDI drum note numbers to canonical instrument lanes.
-GM_NOTE_TO_LANE: Dict[int, str] = {
-    35: "kick", 36: "kick",
-    38: "snare", 40: "snare", 37: "snare", 39: "snare",
-    42: "hh_closed", 44: "hh_closed",
-    46: "hh_open",
-    41: "tom_low", 43: "tom_low",
-    45: "tom_mid", 47: "tom_mid",
-    48: "tom_high", 50: "tom_high",
-    49: "crash", 57: "crash", 55: "crash",
-    51: "ride", 53: "ride", 59: "ride", 52: "ride",
-}
-
-# Normalized list of lane names encountered above.
-LANES: List[str] = sorted(set(GM_NOTE_TO_LANE.values()))
-
-# Default lane remapping used if a caller does not supply their own mapping.
-# It simply maps each lane to itself but allows a single point of customization.
-DEFAULT_LANE_MAP: Dict[str, str] = {lane: lane for lane in LANES}
+from .pattern_constants import GM_NOTE_TO_LANE, LANES, DEFAULT_LANE_MAP  # noqa: F401
 
 
 # ---------------------------------------------------------------------------

--- a/src/beatsmith/pattern_constants.py
+++ b/src/beatsmith/pattern_constants.py
@@ -1,0 +1,36 @@
+"""Shared constants for normalizing drum patterns.
+
+The mapping groups related General MIDI drum notes under a single
+canonical *lane* name (e.g. all snare variants map to ``"snare"``).
+Grouping in this way keeps downstream code simple and consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Map each normalized lane to the General MIDI note numbers that trigger it.
+# Notes are grouped by their musical role rather than strict GM categories.
+LANE_TO_GM_NOTES: Dict[str, List[int]] = {
+    "kick": [35, 36],
+    "snare": [38, 40, 37, 39],
+    "hh_closed": [42, 44],
+    "hh_open": [46],
+    "tom_low": [41, 43],
+    "tom_mid": [45, 47],
+    "tom_high": [48, 50],
+    "crash": [49, 57, 55],
+    "ride": [51, 53, 59, 52],
+}
+
+# Reverse lookup mapping of GM note numbers to lane names.
+GM_NOTE_TO_LANE: Dict[int, str] = {
+    note: lane for lane, notes in LANE_TO_GM_NOTES.items() for note in notes
+}
+
+# Normalized list of lane names encountered above.
+LANES: List[str] = sorted(LANE_TO_GM_NOTES)
+
+# Default lane remapping used if a caller does not supply their own mapping.
+# It simply maps each lane to itself but allows a single point of customization.
+DEFAULT_LANE_MAP: Dict[str, str] = {lane: lane for lane in LANES}

--- a/tools/drum_patterns.py
+++ b/tools/drum_patterns.py
@@ -7,19 +7,7 @@ from pathlib import Path
 
 from mido import MidiFile, merge_tracks
 
-# Mapping of General MIDI drum notes to normalized instrument lanes
-NOTE_TO_LANE = {
-    35: "kick", 36: "kick",
-    38: "snare", 40: "snare", 37: "snare", 39: "snare",
-    42: "hh_closed", 44: "hh_closed",
-    46: "hh_open",
-    41: "tom_low", 43: "tom_low",
-    45: "tom_mid", 47: "tom_mid",
-    48: "tom_high", 50: "tom_high",
-    49: "crash", 57: "crash", 55: "crash",
-    51: "ride", 53: "ride", 59: "ride", 52: "ride",
-}
-LANES = sorted(set(NOTE_TO_LANE.values()))
+from beatsmith.pattern_constants import GM_NOTE_TO_LANE, LANES
 
 
 class PrefixFormatter(logging.Formatter):
@@ -67,7 +55,7 @@ def parse_midi(path: Path, subdivision: int) -> dict:
         elif msg.type == "time_signature":
             time_sig = (msg.numerator, msg.denominator)
         elif msg.type == "note_on" and msg.velocity > 0:
-            lane = NOTE_TO_LANE.get(msg.note)
+            lane = GM_NOTE_TO_LANE.get(msg.note)
             if lane is None:
                 continue
             beats = current_ticks / ticks_per_beat


### PR DESCRIPTION
## Summary
- factor out GM note and lane constants to a shared module
- reuse shared constants in pattern adapter and drum pattern tool
- document how GM notes are grouped into normalized lanes

## Testing
- `ruff check src/beatsmith/pattern_constants.py src/beatsmith/pattern_adapter.py tools/drum_patterns.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7da9ae240833181be1893d4088694